### PR TITLE
Fix gpt_handler debug output

### DIFF
--- a/core/gpt_handler.py
+++ b/core/gpt_handler.py
@@ -2,7 +2,6 @@ import os
 from openai import OpenAI
 
 def ask_jason(prompt):
-    print("🔍 KEY:", os.getenv("OPENAI_API_KEY"))  # DEBUG LINE
     client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
     
     response = client.chat.completions.create(


### PR DESCRIPTION
## Summary
- remove debug logging that exposed the OpenAI API key

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_683e6fa957bc8333ba5bc9e7630503e9